### PR TITLE
changes EXPECT_EQ to EXPECT_NEAR

### DIFF
--- a/test/singa/test_tensor_math.cc
+++ b/test/singa/test_tensor_math.cc
@@ -129,8 +129,8 @@ TEST_F(TensorMath, SoftPlusCpp) {
 
   Tensor p = SoftPlus(cc);
   const float *dptr1 = p.data<float>();
-  EXPECT_EQ(log(2.0f), dptr1[0]);
-  EXPECT_EQ(log(exp(1) + 1.0f), dptr1[1]);
+  EXPECT_NEAR(log(2.0f), dptr1[0], 1e-5);
+  EXPECT_NEAR(log(exp(1) + 1.0f), dptr1[1], 1e-5);
 }
 
 TEST_F(TensorMath, SoftSignCpp) {
@@ -1240,8 +1240,8 @@ TEST_F(TensorMath, SoftPlusCuda) {
   y.ToHost();
 
   const float *dptr = y.data<float>();
-  EXPECT_EQ(dptr[0], log(2.0f));
-  EXPECT_EQ(dptr[1], log(exp(1) + 1.0f));
+  EXPECT_NEAR(dptr[0], log(2.0f), 1e-5);
+  EXPECT_NEAR(dptr[1], log(exp(1) + 1.0f), 1e-5);
 }
 
 TEST_F(TensorMath, SoftSignCuda) {


### PR DESCRIPTION
It will pass the unit test if we change EXPECT_EQ to EXPECT_NEAR, where the small error is due to the computation of exp function.

EXPECT_EQ tests if the two input values are equal to each other
EXPECT_NEAR tests if the absolute difference between the two input values is smaller than a error threshold (uses 1e-5).

